### PR TITLE
in "Remove X authority": Ignore any error & don't exit, continue closing the session

### DIFF
--- a/src/session-child.c
+++ b/src/session-child.c
@@ -771,8 +771,7 @@ session_child_run (int argc, char **argv)
 
         if (error)
             g_printerr ("Error removing X authority: %s\n", error->message);
-        if (!result)
-            _exit (EXIT_FAILURE);
+        /* Ignore this error, don't exit, continue closing the session. */
     }
 
     /* Close the Console Kit session */


### PR DESCRIPTION
...to close PAM etc. anyway.

Otherwise the PAM session might be left open, resources not unmounted/freed, etc.
