### PR TITLE
liblightdm-qt: mark class PowerInterface as exported

### DIFF
--- a/liblightdm-qt/QLightDM/power.h
+++ b/liblightdm-qt/QLightDM/power.h
@@ -16,7 +16,7 @@
 
 namespace QLightDM
 {
-    class PowerInterface : public QObject
+    class Q_DECL_EXPORT PowerInterface : public QObject
     {
         Q_OBJECT
     public:


### PR DESCRIPTION
fix build when using -fvisibility=hidden to stop exporting all symbols