### PR TITLE
Hide systemd's dynamic users

### DIFF
--- a/data/users.conf
+++ b/data/users.conf
@@ -11,4 +11,4 @@
 [UserList]
 minimum-uid=500
 hidden-users=nobody nobody4 noaccess
-hidden-shells=/bin/false /usr/sbin/nologin
+hidden-shells=/bin/false /usr/sbin/nologin /sbin/nologin


### PR DESCRIPTION
systemd creates "dynamic users". These accounts should be hidden from login screen.
But it's possible that systemd creates them with id > 1000 and shell == "/sbin/nologin".

Currently lightdm shows these accounts if AccountService is not installed. See:
https://bbs.archlinux.org/viewtopic.php?id=238704

To fix this, add "/sbin/nologin" to ignored shells.

Please see: http://0pointer.net/blog/dynamic-users-with-systemd.html