### PR TITLE
Fix environment cleaning without clearenv()

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -73,6 +73,10 @@ static GHashTable *processes = NULL;
 static pid_t signal_pid;
 static int signal_pipe[2];
 
+#ifndef HAVE_CLEARENV
+extern char **environ;
+#endif
+
 Process *
 process_get_current (void)
 {


### PR DESCRIPTION
On systems without `clearenv()` the `environ` variable must be imported as external before it can be manipulated to reset the environment.

This is, for example, necessary on FreeBSD, otherwise the effect of `environ = NULL` is a compiler error or in some cases to create a new local variable.