### PR TITLE
Move D-Bus conf file to $(datadir)/dbus-1/system.d

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -4,7 +4,7 @@ dist_init_DATA = init/lightdm.conf
 confdir = $(sysconfdir)/lightdm
 dist_conf_DATA = lightdm.conf users.conf keys.conf
 
-dbusconfdir = $(sysconfdir)/dbus-1/system.d
+dbusconfdir = $(datadir)/dbus-1/system.d
 dist_dbusconf_DATA = org.freedesktop.DisplayManager.conf
 
 pamdir = $(sysconfdir)/pam.d


### PR DESCRIPTION
Since D-Bus 1.9.18 configuration files installed by third-party should
go in $(datadir)/dbus-1/system.d.  The old location is for sysadmin
overrides.

https://lists.freedesktop.org/archives/dbus/2015-July/016746.html